### PR TITLE
Allows user to set base Linear API URL from .env in case of versioning change

### DIFF
--- a/src/LinearApi.php
+++ b/src/LinearApi.php
@@ -18,7 +18,7 @@ class LinearApi extends Connector
 
     public function resolveBaseUrl(): string
     {
-        return 'https://api.linear.app/graphql';
+        return env('LINEAR_BASE_API_URL', 'https://api.linear.app/graphql');
     }
 
     protected function defaultHeaders(): array


### PR DESCRIPTION
This just seemed like a quick change that would be useful, as I recall the Linear team talking about API versioning in the future.